### PR TITLE
mansong1 parameterize client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# jenkins\_windows\_agent
+# jenkins_windows_agent
 
-#### Table of Contents
+## Table of Contents
 
 1. [Overview](#overview)
 2. [Module Dependencies - What are the dependencies](#module-dependencies)
 3. [Module Description - What the module does and why it is useful](#module-description)
-4. [Classifcation Setup - The basics of getting started with jenkins\_windows\_agent](#classification-setup)
-    * [What the jenkins\_agent module affects](#what-the-jenkins_agent-module-affects)
-    * [Setup requirements](#setup-requirements)
+4. [Classifcation Setup - The basics of getting started with jenkins_windows_agent](#classification-setup)
+
+  - [What the jenkins_agent module affects](#what-the-jenkins_agent-module-affects)
+  - [Setup requirements](#setup-requirements)
 
 ## Overview
 
@@ -20,16 +21,16 @@ Please review the [Dependencies](https://forge.puppet.com/ktreese/jenkins_window
 ## Module Description
 
 The Windows Jenkins Agent will be deployed with the following defaults:
- - swarm-client-1.22-jar-with-dependencies.jar
- - mode: exclusive
- - executors: 8
- - labels: windows
- - Agent Home: C:\opt\ci\jenkins
- - Agent Workspace: C:\opt\ci\jenkins\workspace
- - Jenkins Master: http://myjenkinsmaster.localhost:8080
- - java: jdk1.7.0\_79
- - service account: `LocalSystem`
 
+- swarm-client-1.22-jar-with-dependencies.jar
+- mode: exclusive
+- executors: 8
+- labels: windows
+- Agent Home: C:\opt\ci\jenkins
+- Agent Workspace: C:\opt\ci\jenkins\workspace
+- Jenkins Master: <http://myjenkinsmaster.localhost:8080>
+- java: jdk1.7.0_79
+- service account: `LocalSystem`
 
 Puppet will create a windows service `Jenkins_Agent` and set it to run as the `LocalSystem` account
 
@@ -53,9 +54,10 @@ class { 'jenkins_windows_agent':
 }
 ```
 
-### What the jenkins\_agent module affects
+### What the jenkins_agent module affects
 
-###### List of things that the module will alter:
+#### List of things that the module will alter:
+
 ```
  - Installs jdk7
  - Installs NSSM - the Non-Sucking Service Manager
@@ -69,7 +71,7 @@ class { 'jenkins_windows_agent':
 
 Please review the [Module Dependencies](#module-dependencies) section.
 
-Override default values in the Puppet Console, or namespace the key/value pairs appropriately in the desired yaml hieradata file.  At minimum, you'll need to override the `jenkins_master_url`, `jenkins_master_user`, and `jenkins_master_pass` variables to your environments specifications.
+Override default values in the Puppet Console, or namespace the key/value pairs appropriately in the desired yaml hieradata file. At minimum, you'll need to override the `jenkins_master_url`, `jenkins_master_user`, and `jenkins_master_pass` variables to your environments specifications.
 
 For example, to override these variables via hiera:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,12 @@
 #
 #  == Most params are self explanatory
 #
+# [*client_source*]
+#   File source for jenkins slave jar. Default pulls from https://repo.jenkins-ci.org
+#
+# [*version*]
+#   The version of the swarm client code. Default is '1.22'. This should match the plugin version on the master
+#
 # [*verify_peer*]
 #   Boolean: defaults to false
 #   Used in remote_file type to control whether or not to require SSL verification of the the remote server
@@ -43,13 +49,7 @@
 #   Boolean to control whether the service_user should be created
 #   Defaults to false; assumption is made that an AD service account will be used
 #
-# [*client_source*]
-#   File source for jenkins slave jar. Default pulls from https://repo.jenkins-ci.org
 #
-# [*version*]
-#   The version of the swarm client code. Default is '1.22'. This should match the plugin version on the master
-#
-
 class jenkins_windows_agent (
   $client_source       = $::jenkins_windows_agent::params::client_source,
   $version             = $::jenkins_windows_agent::params::version,
@@ -71,10 +71,10 @@ class jenkins_windows_agent (
   $java                = $::jenkins_windows_agent::params::java,
 ) inherits ::jenkins_windows_agent::params {
 
-  $client_jar          = "swarm-client-${version}-jar-with-dependencies.jar"
+  $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
   $client_url = $client_source ? {
-    undef   => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
-    default => $client_source,
+    'repo.jenkins-ci.org' => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
+    default               => $client_source,
   }
 
   #if service_user is set and service_interactive is true; fail

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,7 @@ class jenkins_windows_agent (
   $java                = $::jenkins_windows_agent::params::java,
 ) inherits ::jenkins_windows_agent::params {
 
+  $client_jar          = "swarm-client-${version}-jar-with-dependencies.jar"
   $client_url = $client_source ? {
     undef   => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
     default => $client_source,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,13 @@
 #   Boolean to control whether the service_user should be created
 #   Defaults to false; assumption is made that an AD service account will be used
 #
+# [*client_source*]
+#   File source for jenkins slave jar. Default pulls from https://repo.jenkins-ci.org
+#
+# [*version*]
+#   The version of the swarm client code. Default is '1.22'. This should match the plugin version on the master
+#
+
 class jenkins_windows_agent (
   $client_source       = $::jenkins_windows_agent::params::client_source,
   $version             = $::jenkins_windows_agent::params::version,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,9 +44,8 @@
 #   Defaults to false; assumption is made that an AD service account will be used
 #
 class jenkins_windows_agent (
-  $client_source       = undef,
+  $client_source       = $::jenkins_windows_agent::params::client_source,
   $version             = $::jenkins_windows_agent::params::version,
-  $client_url          = $::jenkins_windows_agent::params::client_url,
   $client_jar          = $::jenkins_windows_agent::params::client_jar,
   $verify_peer         = $::jenkins_windows_agent::params::verify_peer,
   $swarm_mode          = $::jenkins_windows_agent::params::swarm_mode,
@@ -65,6 +64,11 @@ class jenkins_windows_agent (
   $create_user         = $::jenkins_windows_agent::params::create_user,
   $java                = $::jenkins_windows_agent::params::java,
 ) inherits ::jenkins_windows_agent::params {
+
+  $client_url = $client_source ? {
+    undef   => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
+    default => $client_source,
+  }
 
   #if service_user is set and service_interactive is true; fail
   if ($service_user != 'LocalSystem') and ($service_interactive) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,8 @@
 #   Defaults to false; assumption is made that an AD service account will be used
 #
 class jenkins_windows_agent (
+  $client_source       = undef,
+  $version             = $::jenkins_windows_agent::params::version,
   $client_url          = $::jenkins_windows_agent::params::client_url,
   $client_jar          = $::jenkins_windows_agent::params::client_jar,
   $verify_peer         = $::jenkins_windows_agent::params::verify_peer,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,6 @@
 class jenkins_windows_agent (
   $client_source       = $::jenkins_windows_agent::params::client_source,
   $version             = $::jenkins_windows_agent::params::version,
-  $client_jar          = $::jenkins_windows_agent::params::client_jar,
   $verify_peer         = $::jenkins_windows_agent::params::verify_peer,
   $swarm_mode          = $::jenkins_windows_agent::params::swarm_mode,
   $swarm_executors     = $::jenkins_windows_agent::params::swarm_executors,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,8 +4,7 @@
 class jenkins_windows_agent::params {
   $client_source       = undef
   $version             = '1.22'
-  $client_url          = "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/"
-  $client_jar          = "swarm-client-${version}-jar-with-dependencies.jar"
+  $client_url          = undef
   $verify_peer         = false
   $swarm_mode          = 'exclusive'
   $swarm_executors     = '8'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,14 @@
+# Class: jenkins_windows_agent::params
+#
+#
 class jenkins_windows_agent::params {
-  $client_url          = 'https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/1.22/'
-  $client_jar          = 'swarm-client-1.22-jar-with-dependencies.jar'
+  $version      = '1.22'
+  $client_url = $client_source ? {
+    undef   => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
+    default => $client_source,
+  }
+  $client_url          = "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/""
+  $client_jar          = "swarm-client-${version}-jar-with-dependencies.jar"
   $verify_peer         = false
   $swarm_mode          = 'exclusive'
   $swarm_executors     = '8'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,12 +2,9 @@
 #
 #
 class jenkins_windows_agent::params {
-  $version      = '1.22'
-  $client_url = $client_source ? {
-    undef   => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
-    default => $client_source,
-  }
-  $client_url          = "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/""
+  $client_source       = undef
+  $version             = '1.22'
+  $client_url          = "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/"
   $client_jar          = "swarm-client-${version}-jar-with-dependencies.jar"
   $verify_peer         = false
   $swarm_mode          = 'exclusive'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,9 +2,8 @@
 #
 #
 class jenkins_windows_agent::params {
-  $client_source       = undef
+  $client_source       = 'repo.jenkins-ci.org'
   $version             = '1.22'
-  $client_url          = undef
   $verify_peer         = false
   $swarm_mode          = 'exclusive'
   $swarm_executors     = '8'


### PR DESCRIPTION
Creates `version` parameter to build `client_jar` variable and allow override of version.
- was `swarm-client-1.22-jar-with-dependencies.jar`
- is now `swarm-client-${version}-jar-with-dependencies.jar`

Updates README

Makes slight code adjustments to @mansong1 #4 