### PR TITLE
Jdk8 refactor

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,24 +51,27 @@
 #
 #
 class jenkins_windows_agent (
-  $client_source       = $::jenkins_windows_agent::params::client_source,
-  $version             = $::jenkins_windows_agent::params::version,
-  $verify_peer         = $::jenkins_windows_agent::params::verify_peer,
-  $swarm_mode          = $::jenkins_windows_agent::params::swarm_mode,
-  $swarm_executors     = $::jenkins_windows_agent::params::swarm_executors,
-  $swarm_labels        = $::jenkins_windows_agent::params::swarm_labels,
-  $agent_drive         = $::jenkins_windows_agent::params::agent_drive,
-  $agent_home          = $::jenkins_windows_agent::params::agent_home,
-  $jenkins_dirs        = $::jenkins_windows_agent::params::jenkins_dirs,
-  $jenkins_master_url  = $::jenkins_windows_agent::params::jenkins_master_url,
-  $jenkins_master_user = $::jenkins_windows_agent::params::jenkins_master_user,
-  $jenkins_master_pass = $::jenkins_windows_agent::params::jenkins_master_pass,
-  $service_name        = $::jenkins_windows_agent::params::service_name,
-  $service_user        = $::jenkins_windows_agent::params::service_user,
-  $service_pass        = $::jenkins_windows_agent::params::service_pass,
-  $service_interactive = $::jenkins_windows_agent::params::service_interactive,
-  $create_user         = $::jenkins_windows_agent::params::create_user,
-  $java                = $::jenkins_windows_agent::params::java,
+  $client_source            = $::jenkins_windows_agent::params::client_source,
+  $version                  = $::jenkins_windows_agent::params::version,
+  $verify_peer              = $::jenkins_windows_agent::params::verify_peer,
+  $swarm_mode               = $::jenkins_windows_agent::params::swarm_mode,
+  $swarm_executors          = $::jenkins_windows_agent::params::swarm_executors,
+  $swarm_labels             = $::jenkins_windows_agent::params::swarm_labels,
+  $disable_ssl_verification = $::jenkins_windows_agent::params::disable_ssl_verification,
+  $agent_drive              = $::jenkins_windows_agent::params::agent_drive,
+  $agent_home               = $::jenkins_windows_agent::params::agent_home,
+  $jenkins_dirs             = $::jenkins_windows_agent::params::jenkins_dirs,
+  $jenkins_master_url       = $::jenkins_windows_agent::params::jenkins_master_url,
+  $jenkins_master_user      = $::jenkins_windows_agent::params::jenkins_master_user,
+  $jenkins_master_pass      = $::jenkins_windows_agent::params::jenkins_master_pass,
+  $service_name             = $::jenkins_windows_agent::params::service_name,
+  $service_user             = $::jenkins_windows_agent::params::service_user,
+  $service_pass             = $::jenkins_windows_agent::params::service_pass,
+  $service_interactive      = $::jenkins_windows_agent::params::service_interactive,
+  $create_user              = $::jenkins_windows_agent::params::create_user,
+  $jdk                      = $::jenkins_windows_agent::params::jdk,
+  $jdk_choco_version        = $::jenkins_windows_agent::params::jdk_choco_version,
+  $java                     = $::jenkins_windows_agent::params::java,
 ) inherits ::jenkins_windows_agent::params {
 
   $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
@@ -99,8 +102,8 @@ class jenkins_windows_agent (
     value     => 'C:\Program Files\nssm-2.24\win64',
   }
 
-  package { 'jdk7':
-    ensure   => present,
+  package { $jdk:
+    ensure   => $jdk_choco_version,
     provider => 'chocolatey',
     before   => Nssm::Install[$service_name],
   }
@@ -135,7 +138,7 @@ class jenkins_windows_agent (
     service_pass        => $service_pass,
     service_interactive => $service_interactive,
     create_user         => $create_user,
-    app_parameters      => "-jar ${agent_drive}${agent_home}${client_jar} -mode ${swarm_mode} -executors ${swarm_executors} -username ${jenkins_master_user} -password ${jenkins_master_pass} -master ${jenkins_master_url} -labels ${swarm_labels} -fsroot ${agent_drive}${agent_home}",
+    app_parameters      => "-jar ${agent_drive}${agent_home}${client_jar} -mode ${swarm_mode} -executors ${swarm_executors} -username ${jenkins_master_user} -password ${jenkins_master_pass} -master ${jenkins_master_url} -labels ${swarm_labels} -fsroot ${agent_drive}${agent_home} ${disable_ssl_verification}",
     require             => Nssm::Install[$service_name],
     notify              => Service[$service_name],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,5 +22,5 @@ class jenkins_windows_agent::params {
   $create_user              = false
   $jdk                      = 'jdk8'
   $jdk_choco_version        = 'latest'
-  $java                     = '$ENV:JAVA_HOME\bin\java.exe'
+  $java                     = '%JAVA_HOME%\bin\java.exe'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,6 @@ class jenkins_windows_agent::params {
   $service_interactive      = false
   $create_user              = false
   $jdk                      = 'jdk8'
-  $jdk_choco_version        = '8.0.131'
+  $jdk_choco_version        = 'latest'
   $java                     = '$ENV:JAVA_HOME\bin\java.exe'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,5 +22,5 @@ class jenkins_windows_agent::params {
   $create_user              = false
   $jdk                      = 'jdk8'
   $jdk_choco_version        = 'latest'
-  $java                     = '%JAVA_HOME%\bin\java.exe'
+  $java                     = 'java.exe'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class jenkins_windows_agent::params {
   $swarm_mode               = 'exclusive'
   $swarm_executors          = '8'
   $swarm_labels             = 'windows'
-  $disable_ssl_verification = '-disable_ssl_verification'
+  $disable_ssl_verification = '-disableSslVerification'
   $agent_drive              = 'C:'
   $agent_home               = '/opt/ci/jenkins/'
   $jenkins_dirs             = ['/opt/ci/jenkins/', '/opt/ci/jenkins/workspace/', '/tmp']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,22 +2,25 @@
 #
 #
 class jenkins_windows_agent::params {
-  $client_source       = 'repo.jenkins-ci.org'
-  $version             = '1.22'
-  $verify_peer         = false
-  $swarm_mode          = 'exclusive'
-  $swarm_executors     = '8'
-  $swarm_labels        = 'windows'
-  $agent_drive         = 'C:'
-  $agent_home          = '/opt/ci/jenkins/'
-  $jenkins_dirs        = ['/opt/ci/jenkins/', '/opt/ci/jenkins/workspace/', '/tmp']
-  $jenkins_master_url  = 'http://myjenkinsmaster.localhost:8080'
-  $jenkins_master_user = 'jenkins'
-  $jenkins_master_pass = 'pass123'
-  $service_name        = 'Jenkins_Agent'
-  $service_user        = 'LocalSystem'
-  $service_pass        = undef
-  $service_interactive = false
-  $create_user         = false
-  $java                = 'C:\Program Files\Java\jdk1.7.0_79\bin\java.exe'
+  $client_source            = 'repo.jenkins-ci.org'
+  $version                  = '3.3'
+  $verify_peer              = false
+  $swarm_mode               = 'exclusive'
+  $swarm_executors          = '8'
+  $swarm_labels             = 'windows'
+  $disable_ssl_verification = '-disable_ssl_verification'
+  $agent_drive              = 'C:'
+  $agent_home               = '/opt/ci/jenkins/'
+  $jenkins_dirs             = ['/opt/ci/jenkins/', '/opt/ci/jenkins/workspace/', '/tmp']
+  $jenkins_master_url       = 'http://myjenkinsmaster.localhost:8080'
+  $jenkins_master_user      = 'jenkins'
+  $jenkins_master_pass      = 'pass123'
+  $service_name             = 'Jenkins_Agent'
+  $service_user             = 'LocalSystem'
+  $service_pass             = undef
+  $service_interactive      = false
+  $create_user              = false
+  $jdk                      = 'jdk8'
+  $jdk_choco_version        = '8.0.131'
+  $java                     = '$ENV:JAVA_HOME\bin\java.exe'
 }


### PR DESCRIPTION
- upgrades jdk to jdk8 (choco jdk7 is currently broken)
- defaults the installation of latest version of jdk8
- Adds jenkins swarm option to disable ssl verification
- Removes absolute path to `$program`.  In this example, java.exe is included in windows PATH