### PR TITLE
3.3 jar with dependencies fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please review the [Dependencies](https://forge.puppet.com/ktreese/jenkins_window
 
 The Windows Jenkins Agent will be deployed with the following defaults:
 
-- swarm-client-3.3-jar-with-dependencies.jar
+- swarm-client-3.3.jar ([JENKINS-42138](https://issues.jenkins-ci.org/browse/JENKINS-42138) indicates this jar contains the dependencies)
 - mode: exclusive
 - executors: 8
 - labels: windows

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,7 @@
 class jenkins_windows_agent (
   $client_source            = $::jenkins_windows_agent::params::client_source,
   $version                  = $::jenkins_windows_agent::params::version,
+  $client_jar               = $::jenkins_windows_agent::params::client_jar,
   $verify_peer              = $::jenkins_windows_agent::params::verify_peer,
   $swarm_mode               = $::jenkins_windows_agent::params::swarm_mode,
   $swarm_executors          = $::jenkins_windows_agent::params::swarm_executors,
@@ -74,7 +75,6 @@ class jenkins_windows_agent (
   $java                     = $::jenkins_windows_agent::params::java,
 ) inherits ::jenkins_windows_agent::params {
 
-  $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
   $client_url = $client_source ? {
     'repo.jenkins-ci.org' => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
     default               => $client_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@
 class jenkins_windows_agent::params {
   $client_source            = 'repo.jenkins-ci.org'
   $version                  = '3.3'
+  $client_jar               = "swarm-client-${version}.jar"
   $verify_peer              = false
   $swarm_mode               = 'exclusive'
   $swarm_executors          = '8'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ktreese-jenkins_windows_agent",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Kris Reese",
   "summary": "Module for deploying a Jenkins Agent for Windows via the swarm jar",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Corrects download link for the 3.3 swarm client.
  - Refer [JENKINS-42138](https://issues.jenkins-ci.org/browse/JENKINS-42138)
- Moves `client_jar` into params to allow for override.