### PR TITLE
3.3 jar with dependencies fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,11 +74,10 @@ class jenkins_windows_agent (
   $java                     = $::jenkins_windows_agent::params::java,
 ) inherits ::jenkins_windows_agent::params {
 
-
-  # versioncmp function returns 1 if 3.3 is greater than $version
-  # version 3.3 is first version to remove '-jar-with-dependencies'
-  # portion of the name from the jar file name
-  if versioncmp('3.3', $version) > 0 {
+  # versioncmp function returns -1 if 2.2 is less than $version
+  # version 2.2 is last version to contain the portion '-jar-with-dependencies'
+  # as part of the jar file name
+  if versioncmp('2.2', $version) < 0 {
     $client_jar = "swarm-client-${version}.jar"
   } else {
     $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,6 @@
 class jenkins_windows_agent (
   $client_source            = $::jenkins_windows_agent::params::client_source,
   $version                  = $::jenkins_windows_agent::params::version,
-  $client_jar               = $::jenkins_windows_agent::params::client_jar,
   $verify_peer              = $::jenkins_windows_agent::params::verify_peer,
   $swarm_mode               = $::jenkins_windows_agent::params::swarm_mode,
   $swarm_executors          = $::jenkins_windows_agent::params::swarm_executors,
@@ -74,6 +73,16 @@ class jenkins_windows_agent (
   $jdk_choco_version        = $::jenkins_windows_agent::params::jdk_choco_version,
   $java                     = $::jenkins_windows_agent::params::java,
 ) inherits ::jenkins_windows_agent::params {
+
+
+  # versioncmp function returns 1 if 3.3 is greater than $version
+  # version 3.3 is first version to remove '-jar-with-dependencies'
+  # portion of the name from the jar file name
+  if versioncmp('3.3', $version) > 0 {
+    $client_jar = "swarm-client-${version}.jar"
+  } else {
+    $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
+  }
 
   $client_url = $client_source ? {
     'repo.jenkins-ci.org' => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,6 @@
 class jenkins_windows_agent::params {
   $client_source            = 'repo.jenkins-ci.org'
   $version                  = '3.3'
-  $client_jar               = "swarm-client-${version}.jar"
   $verify_peer              = false
   $swarm_mode               = 'exclusive'
   $swarm_executors          = '8'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ktreese-jenkins_windows_agent",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Kris Reese",
   "summary": "Module for deploying a Jenkins Agent for Windows via the swarm jar",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Removes `client_jar` from params.  In the event of a hiera override, the constructed value of `client_jar` would be different between the params class and the jenkins_windows_agent class
- Programmatically determine the value of `client_jar` depending on the desired version wanted.