### PR TITLE
switch windows env dep from badgerious to puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     {"name":"chocolatey/chocolatey","version_requirement":">= 1.2.5"},
     {"name":"lwf/remote_file","version_requirement":">= 1.0.1"},
     {"name":"counsyl/windows","version_requirement":">= 1.0.2"},
-    {"name":"badgerious/windows_env","version_requirement":">= 2.2.2"},
+    {"name":"puppet/windows_env","version_requirement":">= 3.1.0"},
     {"name":"ktreese/nssm","version_requirement":">= 1.0.0"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
With the current usage of 'windows_env' puppet/windows_env was a drop in replacement. I updated the metadata.json dependencies to use puppet/windows_env.

Resolves #12 